### PR TITLE
fix typos

### DIFF
--- a/adr-005-user-facing-config.md
+++ b/adr-005-user-facing-config.md
@@ -4,7 +4,7 @@
 
 Per [ADR-003](adr-003-config-implementation.md), Arachne uses
 Datomic-shaped data for configuration. Although this is a flexible,
-extensible data structure which is a great fit for programmmatic
+extensible data structure which is a great fit for programmatic
 manipulation, in its literal form it is quite verbose.
 
 It is quite difficult to understand the structure of Datomic data by

--- a/adr-005-user-facing-config.md
+++ b/adr-005-user-facing-config.md
@@ -4,7 +4,7 @@
 
 Per [ADR-003](adr-003-config-implementation.md), Arachne uses
 Datomic-shaped data for configuration. Although this is a flexible,
-extensible data structure which is a great fit for progammatic
+extensible data structure which is a great fit for programmmatic
 manipulation, in its literal form it is quite verbose.
 
 It is quite difficult to understand the structure of Datomic data by
@@ -74,7 +74,7 @@ runtime application.
 
 To further emphasize the difference between configuration scripts and
 runtime code, and because they are not on the classpath, configuration
-scripts will not have namespaces and will instead include eachother
+scripts will not have namespaces and will instead include each other
 via Clojure's `load` function.
 
 Arachne will provide code supporting the ability of module authors to
@@ -99,7 +99,7 @@ You could write the corresponding DSL:
 (server :id :my.app/server, :port 8080, :debug true)
 ```
 
-Note that this is a illustrative example and does not represent the
+Note that this is an illustrative example and does not represent the
 actual DSL or config for the HTTP module.
 
 DSLs should make heavy use of Spec to make errors as comprehensible as possible.
@@ -114,7 +114,7 @@ Proposed
   without writing config data by hand.
 - Users will have access to the full power of the Clojure programming
   language when configuring their application. This grants a great deal
-  of power and flexibility, but also the risk of users doing unadvisable
+  of power and flexibility, but also the risk of users doing inadvisable
   things in their config scripts (e.g, non-repeatable side effects.)
 - Module authors will bear the responsibility of providing
   an appropriate, user-friendly DSL interface to their configuration data.

--- a/adr-006-core-runtime.md
+++ b/adr-006-core-runtime.md
@@ -17,14 +17,14 @@ There are several logically inherent subtasks to this bootstrapping process, whi
     - Reading the initial user-supplied configuration (i.e, the configuration scripts from [ADR-005](adr-005-user-facing-config.md))
     - Initializing the Arachne configuration given a project's set of modules (described in [ADR-002](adr-002-configuration.md) and [ADR-004](adr-004-module-loading.md))
 - Application Specific
-    - Instantiate user and module-defined objects that needs to exist at runtime.
+    - Instantiate user and module-defined objects that need to exist at runtime.
     - Start and stop user and module-defined services
 
 As discussed in [ADR-004](adr-004-module-loading.md), tasks in the "starting the JVM" category are not in-scope for Arachne; rather, they are offloaded to whatever build/dependency tool the project is using (usually either [boot](http://boot-clj.com) or [leiningen](http://leiningen.org).)
 
 This leaves the Arachne and application-specific startup tasks. Arachne should provide an orderly, structured startup (and shutdown) procedure, and make it possible for modules and application authors to hook into it to ensure that their own code initializes, starts and stops as desired.
 
-Additionally, it must be possible for different system components to have dependencies on eachother, such that when starting, services start *after* the services upon which they depend. Stopping should occur in reverse-dependency order, such that a service is never in a state where it is running but one of its dependencies is stopped.
+Additionally, it must be possible for different system components to have dependencies on each other, such that when starting, services start *after* the services upon which they depend. Stopping should occur in reverse-dependency order, such that a service is never in a state where it is running but one of its dependencies is stopped.
 
 ## Decision
 
@@ -32,7 +32,7 @@ Additionally, it must be possible for different system components to have depend
 
 Arachne uses the [Component](https://github.com/stuartsierra/component) library to manage system components. Instead of requiring users to define a component system map manually, however, Arachne itself builds one based upon the Arachne config via *Configuration Entities* that appear in the configuration.
 
-Component entities may be added to the config directly by end users (via a initialization script as per [ADR-005](adr-005-user-facing-config.md)), or by modules in their `configure` function ([ADR-004](module-loading.md).)
+Component entities may be added to the config directly by end users (via an initialization script as per [ADR-005](adr-005-user-facing-config.md)), or by modules in their `configure` function ([ADR-004](module-loading.md).)
 
 Component entities have attributes which indicates which other components they depend upon. Circular dependencies are not allowed; the component dependency structure must form a Directed Acyclic Graph (DAG.) The dependency attributes also specify the key that Component will use to `assoc` dependencies.
 
@@ -44,13 +44,13 @@ The top-level entity in an Arachne system is a reified *Arachne Runtime* object.
 
 The constructor function for a Runtime takes a configuration value and some number of "roots"; entity IDs or lookup refs of Component entities in the config. Only these root components and their transitive dependencies will be instantiated or added to the Component system. In other words, only component entities that are actually used will be instantiated; unused component entities defined in the config will be ignored.
 
-A `lookup` function will be provided to find the runtime object instance of a component, given its entity ID or lookup ref in the configuraiton.
+A `lookup` function will be provided to find the runtime object instance of a component, given its entity ID or lookup ref in the configuration.
 
 #### Startup Procedure
 
 Arachne will rely upon an external build tool (such as boot or leiningen.) to handle downloading dependencies, assembling a classpath, and starting a JVM.
 
-Once JVM with the correct classpath is running, the following steps are required to yield a running Arachne runtime:
+Once a JVM with the correct classpath is running, the following steps are required to yield a running Arachne runtime:
 
 1. Determine a set of modules to use (the "active modules")
 2. Build a configuration schema by querying each active module using its `schema` function ([ADR-004](module-loading.md))
@@ -70,5 +70,5 @@ PROPOSED
 
 - It is possible to fully define the system components and their dependencies in an application's configuration. This is how Arachne achieves dependency injection and inversion of control.
 - It is possible to explicitly create, start and stop Arachne runtimes.
-- Multiple Arachne runtimes may co-exist in the same JVM (although they may conflict and fail to start if they both attempt to use a global resource such as a HTTP port)
+- Multiple Arachne runtimes may co-exist in the same JVM (although they may conflict and fail to start if they both attempt to use a global resource such as an HTTP port)
 - By specifying different root components when constructing a runtime, it is possible to run different types of Arachne applications based on the same Arachne configuration value.

--- a/adr-007-configuration-updates.md
+++ b/adr-007-configuration-updates.md
@@ -6,13 +6,13 @@ A core part of the process of developing an application is making changes to its
 
 In a development context, developers will want to see these changes reflected in their running application as quickly as possible. Keeping the test/modify cycle short is an important goal.
 
-However, accomodating change is a source of complexity. Extra code would be required to handle  "update" scenarios. Components are initialized with a particular configuration in hand. While it would be possible to require that every component support an `update` operation to recieve an arbitrary new config, implementing this is non-trivial and would likely need to involve conditional logic to determine the ways in which the new configuration is different from the old. If any mistakes where made in the implementation of `update`, *for any component*, such that the result was not identical to a clean restart, it would be possible to put the system in an inconsistent, unreproducible state.
+However, accommodating change is a source of complexity. Extra code would be required to handle  "update" scenarios. Components are initialized with a particular configuration in hand. While it would be possible to require that every component support an `update` operation to receive an arbitrary new config, implementing this is non-trivial and would likely need to involve conditional logic to determine the ways in which the new configuration is different from the old. If any mistakes where made in the implementation of `update`, *for any component*, such that the result was not identical to a clean restart, it would be possible to put the system in an inconsistent, unreproducible state.
 
 The "simplest" approach is to avoid the issue and completely discard and rebuild the Arachne runtime ([ADR-006](adr-006-core-runtime)) every time the configuration is updated. Every modification to the config would be applied via a clean start, guaranteeing reproducibility and a single code path.
 
 However, this simple baseline approach has two major drawbacks:
 
-1. The initialization, shutdown and startup times of the entire set of components will be incurred every time the configuration is updated.
+1. The shutdown, initialization, and startup times of the entire set of components will be incurred every time the configuration is updated.
 2. The developer will lose any application state stored in the components whenever the config is modified.
 
 The startup and shutdown time issues are potentially problematic because of the general increase to cycle time. However, it might not be too bad depending on exactly how long it takes sub-components to start. Most commonly-used components take only a few milliseconds to rebuild and restart. This is a cost that most Component workflows absorb without too much trouble.
@@ -38,7 +38,7 @@ Whenever the configuration changes, the following procedure will be used:
 4. The `preserve` function will selectively copy state out of the old, stopped component into the new, not-yet-started component. It should be careful not to copy any state that would be invalidated by a configuration change.
 5. Call `start` on the new runtime.
 
-Arachne will not provide a mitigation for avoiding the cost of stopping and starting individual components. If this becomes a pain point, we can explore solutions such as taht offered by Suspendable.
+Arachne will not provide a mitigation for avoiding the cost of stopping and starting individual components. If this becomes a pain point, we can explore solutions such as that offered by Suspendable.
  
 ## Status
 


### PR DESCRIPTION
Fix a couple typos.

Switch to the more common usage of inadvisable over unadvisable to cater to the ear of the masses.

Change "a http request " to "an http request" to match the phonetic pronunciation of the letter "h" which sounds like "aich", which starts with a vowel sound.